### PR TITLE
avoid re-settling already settled DLC

### DIFF
--- a/cashu/mint/db/write.py
+++ b/cashu/mint/db/write.py
@@ -316,6 +316,7 @@ class DbWriteHelper:
                             dlc_root=settlement.dlc_root,
                             details="DLC already settled"
                         ))
+                        continue
 
                     assert settlement.outcome
                     await self.crud.set_dlc_settled_and_debts(settlement.dlc_root, settlement.outcome.P, self.db, conn)


### PR DESCRIPTION
I think this `continue` was missing as I'm pretty sure we don't want to re-run `set_dlc_settled_and_debts` on a DLC which has already been marked as settled.