### PR TITLE
refactor response types/structure to match spec

### DIFF
--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -1243,8 +1243,11 @@ class DlcFundingProof(BaseModel):
     or a dlc merkle root with bad inputs.
     """
     dlc_root: str
-    signature: Optional[str] = None
-    bad_inputs: Optional[List[DlcBadInput]] = None # Used to specify potential errors
+    signature: str
+
+class DlcFundingError(BaseModel):
+    dlc_root: str
+    bad_inputs: Optional[List[DlcBadInput]] # Used to specify potential errors
 
 class DlcOutcome(BaseModel):
     """
@@ -1259,9 +1262,21 @@ class DlcSettlement(BaseModel):
     Data used to settle an outcome of a DLC
     """
     dlc_root: str
-    outcome: Optional[DlcOutcome] = None
-    merkle_proof: Optional[List[str]] = None
-    details: Optional[str] = None
+    outcome: DlcOutcome
+    merkle_proof: List[str]
+
+class DlcSettlementAck(BaseModel):
+    """
+    Used by the mint to indicate the success of a DLC's funding, settlement, etc.
+    """
+    dlc_root: str
+
+class DlcSettlementError(BaseModel):
+    """
+    Indicates to the client that a DLC operation (funding, settlement, etc) failed.
+    """
+    dlc_root: str
+    details: str
 
 class DlcPayoutForm(BaseModel):
     dlc_root: str

--- a/cashu/core/base.py
+++ b/cashu/core/base.py
@@ -1242,8 +1242,12 @@ class DlcFundingProof(BaseModel):
     A dlc merkle root with its signature
     or a dlc merkle root with bad inputs.
     """
-    dlc_root: str
+    keyset: str
     signature: str
+
+class DlcFundingAck(BaseModel):
+    dlc_root: str
+    funding_proof: DlcFundingProof
 
 class DlcFundingError(BaseModel):
     dlc_root: str

--- a/cashu/core/models.py
+++ b/cashu/core/models.py
@@ -7,8 +7,8 @@ from .base import (
     BlindedMessage_Deprecated,
     BlindedSignature,
     DiscreetLogContract,
+    DlcFundingAck,
     DlcFundingError,
-    DlcFundingProof,
     DlcPayout,
     DlcPayoutForm,
     DlcSettlement,
@@ -340,7 +340,7 @@ class PostDlcRegistrationRequest(BaseModel):
     registrations: List[DiscreetLogContract]
 
 class PostDlcRegistrationResponse(BaseModel):
-    funded: List[DlcFundingProof] = []
+    funded: List[DlcFundingAck] = []
     errors: Optional[List[DlcFundingError]] = None
 
 # ------- API: DLC SETTLEMENT -------

--- a/cashu/core/models.py
+++ b/cashu/core/models.py
@@ -7,10 +7,13 @@ from .base import (
     BlindedMessage_Deprecated,
     BlindedSignature,
     DiscreetLogContract,
+    DlcFundingError,
     DlcFundingProof,
     DlcPayout,
     DlcPayoutForm,
     DlcSettlement,
+    DlcSettlementAck,
+    DlcSettlementError,
     MeltQuote,
     MintQuote,
     Proof,
@@ -338,7 +341,7 @@ class PostDlcRegistrationRequest(BaseModel):
 
 class PostDlcRegistrationResponse(BaseModel):
     funded: List[DlcFundingProof] = []
-    errors: Optional[List[DlcFundingProof]] = None
+    errors: Optional[List[DlcFundingError]] = None
 
 # ------- API: DLC SETTLEMENT -------
 
@@ -346,8 +349,8 @@ class PostDlcSettleRequest(BaseModel):
     settlements: List[DlcSettlement]
 
 class PostDlcSettleResponse(BaseModel):
-    settled: List[DlcSettlement] = []
-    errors: Optional[List[DlcSettlement]] = None
+    settled: List[DlcSettlementAck] = []
+    errors: Optional[List[DlcSettlementError]] = None
 
 # ------- API: DLC PAYOUT -------
 class PostDlcPayoutRequest(BaseModel):

--- a/cashu/mint/db/write.py
+++ b/cashu/mint/db/write.py
@@ -5,8 +5,8 @@ from loguru import logger
 from ...core.base import (
     DiscreetLogContract,
     DlcBadInput,
+    DlcFundingAck,
     DlcFundingError,
-    DlcFundingProof,
     DlcSettlement,
     DlcSettlementAck,
     DlcSettlementError,
@@ -235,19 +235,19 @@ class DbWriteHelper:
 
     async def _verify_proofs_and_dlc_registrations(
         self,
-        registrations: List[Tuple[DiscreetLogContract, DlcFundingProof]],
-    ) -> Tuple[List[Tuple[DiscreetLogContract, DlcFundingProof]], List[DlcFundingError]]:
+        registrations: List[Tuple[DiscreetLogContract, DlcFundingAck]],
+    ) -> Tuple[List[Tuple[DiscreetLogContract, DlcFundingAck]], List[DlcFundingError]]:
         """
         Method to check if proofs are already spent or registrations already registered. If they are not, we
         set them as spent and registered respectively
         Args:
-            registrations (List[Tuple[DiscreetLogContract, DlcFundingProof]]): List of registrations.
+            registrations (List[Tuple[DiscreetLogContract, DlcFundingAck]]): List of registrations.
         Returns:
-            List[Tuple[DiscreetLogContract, DlcFundingProof]]: a list of registered DLCs
-            List[DlcFundingProof]: a list of errors
+            List[Tuple[DiscreetLogContract, DlcFundingAck]]: a list of registered DLCs
+            List[DlcFundingError]: a list of errors
         """
-        checked: List[Tuple[DiscreetLogContract, DlcFundingProof]] = []
-        registered: List[Tuple[DiscreetLogContract, DlcFundingProof]] = []
+        checked: List[Tuple[DiscreetLogContract, DlcFundingAck]] = []
+        registered: List[Tuple[DiscreetLogContract, DlcFundingAck]] = []
         errors: List[DlcFundingError]= []
         if len(registrations) == 0:
             logger.trace("Received 0 registrations")

--- a/cashu/mint/ledger.py
+++ b/cashu/mint/ledger.py
@@ -12,8 +12,10 @@ from ..core.base import (
     BlindedSignature,
     DiscreetLogContract,
     DlcBadInput,
+    DlcFundingError,
     DlcFundingProof,
     DlcSettlement,
+    DlcSettlementError,
     MeltQuote,
     MeltQuoteState,
     Method,
@@ -1133,7 +1135,7 @@ class Ledger(LedgerVerification, LedgerSpendingConditions, LedgerTasks, LedgerFe
         """
         logger.trace("register called")
         funded: List[Tuple[DiscreetLogContract, DlcFundingProof]] = []
-        errors: List[DlcFundingProof] = []
+        errors: List[DlcFundingError] = []
         for registration in request.registrations:
             try:
                 logger.trace(f"processing registration {registration.dlc_root}")
@@ -1175,7 +1177,7 @@ class Ledger(LedgerVerification, LedgerSpendingConditions, LedgerTasks, LedgerFe
                 logger.error(f"registration {registration.dlc_root} failed")
                 # Generic Error
                 if isinstance(e, TransactionError):
-                    errors.append(DlcFundingProof(
+                    errors.append(DlcFundingError(
                         dlc_root=registration.dlc_root,
                         bad_inputs=[DlcBadInput(
                             index=-1,
@@ -1184,7 +1186,7 @@ class Ledger(LedgerVerification, LedgerSpendingConditions, LedgerTasks, LedgerFe
                     ))
                 # DLC verification fail
                 else:
-                    errors.append(DlcFundingProof(
+                    errors.append(DlcFundingError(
                         dlc_root=registration.dlc_root,
                         bad_inputs=e.bad_inputs,
                     ))
@@ -1207,7 +1209,7 @@ class Ledger(LedgerVerification, LedgerSpendingConditions, LedgerTasks, LedgerFe
         """
         logger.trace("settle called")
         verified: List[DlcSettlement] = []
-        errors: List[DlcSettlement] = []
+        errors: List[DlcSettlementError] = []
         for settlement in request.settlements:
             try:
                 # Verify inclusion of payout structure and associated attestation in the DLC
@@ -1215,7 +1217,7 @@ class Ledger(LedgerVerification, LedgerSpendingConditions, LedgerTasks, LedgerFe
                 await self._verify_dlc_inclusion(settlement.dlc_root, settlement.outcome, settlement.merkle_proof)
                 verified.append(settlement)
             except (DlcSettlementFail, AssertionError) as e:
-                errors.append(DlcSettlement(
+                errors.append(DlcSettlementError(
                     dlc_root=settlement.dlc_root,
                     details=e.detail if isinstance(e, DlcSettlementFail) else str(e)
                 ))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,6 +139,6 @@ def mint():
 
     server = UvicornServer(config=config)
     server.start()
-    time.sleep(1)
+    time.sleep(5)
     yield server
     server.stop()

--- a/tests/test_dlc.py
+++ b/tests/test_dlc.py
@@ -310,8 +310,8 @@ async def test_registration_vanilla_proofs(wallet: Wallet, ledger: Ledger):
     response = await ledger.register_dlc(request)
     assert len(response.funded) == 1, "Funding proofs len != 1"
 
-    funding_proof = response.funded[0]
-    assert verify_dlc_signature(dlc_root, 64, bytes.fromhex(funding_proof.signature), pubkey),\
+    ack = response.funded[0]
+    assert verify_dlc_signature(dlc_root, 64, bytes.fromhex(ack.funding_proof.signature), pubkey),\
         "Could not verify funding proof"
 
 @pytest.mark.asyncio
@@ -345,8 +345,8 @@ async def test_registration_dlc_locked_proofs(wallet: Wallet, ledger: Ledger):
     assert response.errors is None, f"Funding proofs error: {response.errors[0].bad_inputs}"
     assert len(response.funded) == 1, "Funding proofs len != 1"
 
-    funding_proof = response.funded[0]
-    assert verify_dlc_signature(dlc_root, 64, bytes.fromhex(funding_proof.signature), pubkey), \
+    ack = response.funded[0]
+    assert verify_dlc_signature(dlc_root, 64, bytes.fromhex(ack.funding_proof.signature), pubkey), \
         "Could not verify funding proof"
 
 
@@ -508,7 +508,7 @@ async def test_settle_dlc(wallet: Wallet, ledger: Ledger):
 
     request = PostDlcRegistrationRequest(registrations=[dlc])
     response = await ledger.register_dlc(request)
-    assert response.errors is None, f"Funding proofs error: {response.errors[0].bad_inputs}"    
+    assert response.errors is None, f"Funding proofs error: {response.errors[0].bad_inputs}"
 
     outcome = DlcOutcome(
         P=json.dumps(payouts[1]),
@@ -558,7 +558,7 @@ async def test_settle_dlc_timeout(wallet: Wallet, ledger: Ledger):
 
     request = PostDlcRegistrationRequest(registrations=[dlc])
     response = await ledger.register_dlc(request)
-    assert response.errors is None, f"Funding proofs error: {response.errors[0].bad_inputs}"    
+    assert response.errors is None, f"Funding proofs error: {response.errors[0].bad_inputs}"
 
     outcome = DlcOutcome(
         P=json.dumps(payouts[2]),


### PR DESCRIPTION
Currently the code reuses some types (`DlcFundingProof`, `DlcOutcome`) to contain error messages. This is poor hygiene and I wanted to clean it up while also bringing the response structure in line with the [latest changes to the spec](https://github.com/cashubtc/nuts/pull/128/commits/95f47ba6f71ef2c525d06afc0df80e4d851ba7eb)